### PR TITLE
Improve MyLead token handling and ignore generated token

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+mylead_token.txt
+__pycache__/
+*.pyc
+output/


### PR DESCRIPTION
## Summary
- raise a clear RuntimeError when `mylead_token.txt` is missing and build request headers with the loader
- add `.gitignore` to prevent committing generated token and build artifacts

## Testing
- `ruff check .`
- `mypy .` *(fails: Library stubs not installed for "requests", "pandas"; attempted `pip install types-requests pandas-stubs` but proxy returned 403)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68950fe53a54832f85f741ae1be3ec40