### PR TITLE
Add setup helper script

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -e
+
+pip install -r requirements.txt
+playwright install
+
+echo "Reminder: Copy .env.example to .env and populate credentials."


### PR DESCRIPTION
## Summary
- add setup.sh to install dependencies and Playwright components
- remind users to copy .env.example to .env

## Testing
- `pytest -q`
- `ruff check .`
- `mypy .` *(fails: Library stubs not installed for "requests" and "pandas"; tried `mypy --install-types --non-interactive`, which could not install `pandas-stubs` due to connection issues)*

------
https://chatgpt.com/codex/tasks/task_e_689519e0a1a0832f82833bcddfde4891