### PR TITLE
Add example environment configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,14 @@
+# MyLead credentials for token generation
+MYLEAD_USERNAME=
+MYLEAD_PASSWORD=
+
+# OGAds credentials
+OGADS_EMAIL=
+OGADS_PASSWORD=
+
+# CPAGrip credentials
+CPAGRIP_USERNAME=
+CPAGRIP_PASSWORD=
+
+# Optional: enable to save Playwright screenshots on errors
+DEBUG_SCREENSHOTS=


### PR DESCRIPTION
## Summary
- add `.env.example` with placeholders for MyLead, OGAds, and CPAGrip credentials
- document optional `DEBUG_SCREENSHOTS` flag used by fetchers

## Testing
- `ruff check .`
- `mypy .` *(fails: Library stubs not installed for "requests", "pandas")*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689519cccdcc832fa65efba5e220a15b