### PR TITLE
Add stub packages for typing

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ playwright==1.42.0
 requests==2.31.0
 pandas==2.1.4
 python-dotenv==1.0.0
+types-requests
+pandas-stubs


### PR DESCRIPTION
## Summary
- add types-requests and pandas-stubs to requirements for improved type checking

## Testing
- `ruff check .`
- `pytest -q`
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement types-requests; 403 from proxy)*
- `mypy .` *(fails: Library stubs not installed for "requests" and "pandas" due to missing packages)*

------
https://chatgpt.com/codex/tasks/task_e_689519e47f14832fb1fb88ad93d013a5