### PR TITLE
Add unit tests for token parsing and fetcher helpers

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+testpaths = tests

--- a/tests/test_fetchers.py
+++ b/tests/test_fetchers.py
@@ -1,0 +1,50 @@
+from pathlib import Path
+import sys
+from unittest.mock import MagicMock
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+from fetchers.ogads_fetcher import _parse_offer_row
+from fetchers.cpagrip_fetcher import _parse_payout, _validate_offer
+
+
+def make_element(text=None, href=None):
+    element = MagicMock()
+    element.inner_text.return_value = text
+    element.get_attribute.side_effect = lambda name: href if name == "href" else None
+    return element
+
+
+def test_parse_offer_row():
+    row = MagicMock()
+    row.query_selector.side_effect = lambda selector: {
+        '.offer-name': make_element('Test Offer'),
+        '.offer-payout': make_element('$5.00'),
+        '.offer-device': make_element('Mobile'),
+        '.offer-category': make_element('Games'),
+        '.offer-link a': make_element(href='/offer/1'),
+        '.offer-restrictions': make_element('No login, Reddit allowed'),
+    }[selector]
+    row.query_selector_all.side_effect = lambda selector: {
+        '.offer-geo .geo-tag': [make_element('US'), make_element('CA')],
+    }[selector]
+
+    offer = _parse_offer_row(row)
+    assert offer['name'] == 'Test Offer'
+    assert offer['payout'] == 5.0
+    assert offer['geo'] == ['US', 'CA']
+    assert offer['url'] == 'https://ogads.com/offer/1'
+    assert 'no-login' in offer['tags']
+    assert 'Reddit-safe' in offer['tags']
+    assert 'mobile' in offer['tags']
+
+
+def test_parse_payout():
+    assert _parse_payout('$1,234.56') == 1234.56
+    assert _parse_payout('invalid') is None
+
+
+def test_validate_offer():
+    valid = {'name': 'A', 'url': 'http://a', 'geo': ['US'], 'payout': 1.0}
+    invalid = {'name': 'B', 'url': '', 'geo': ['US'], 'payout': 1.0}
+    assert _validate_offer(valid)
+    assert not _validate_offer(invalid)

--- a/tests/test_mylead_token.py
+++ b/tests/test_mylead_token.py
@@ -1,0 +1,44 @@
+from pathlib import Path
+import sys
+import requests
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+import get_mylead_token
+
+
+def test_main_success(monkeypatch, tmp_path, capsys):
+    monkeypatch.setenv("MYLEAD_USERNAME", "user")
+    monkeypatch.setenv("MYLEAD_PASSWORD", "pass")
+    monkeypatch.chdir(tmp_path)
+
+    class MockResponse:
+        status_code = 200
+        reason = "OK"
+
+        def json(self):
+            return {"access_token": "token123"}
+
+    monkeypatch.setattr(requests, "post", lambda *a, **k: MockResponse())
+    get_mylead_token.main()
+
+    token_file = tmp_path / "mylead_token.txt"
+    assert token_file.read_text() == "token123"
+    output = capsys.readouterr().out
+    assert "✔️ MyLead login successful" in output
+
+
+def test_main_request_error(monkeypatch, tmp_path, capsys):
+    monkeypatch.setenv("MYLEAD_USERNAME", "user")
+    monkeypatch.setenv("MYLEAD_PASSWORD", "pass")
+    monkeypatch.chdir(tmp_path)
+
+    def raise_error(*args, **kwargs):
+        raise requests.RequestException("network error")
+
+    monkeypatch.setattr(requests, "post", raise_error)
+    get_mylead_token.main()
+
+    token_file = tmp_path / "mylead_token.txt"
+    assert not token_file.exists()
+    output = capsys.readouterr().out
+    assert "Login failed" in output


### PR DESCRIPTION
## Summary
- add tests for MyLead token retrieval success and network errors
- add tests for OGAds offer row parsing and CPAGrip helpers
- configure pytest to discover tests

## Testing
- `ruff check .`
- `mypy .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68951f469948832fb468b675c4c5c04c