### PR TITLE
feat: persist MyLead token and publish offer feed

### DIFF
--- a/.github/workflows/fetch-and-sync.yml
+++ b/.github/workflows/fetch-and-sync.yml
@@ -1,0 +1,40 @@
+name: Fetch and Sync Offers
+
+on:
+  schedule:
+    - cron: '0 4 * * *'
+  workflow_dispatch:
+
+jobs:
+  fetch-and-sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Fetch MyLead token
+        env:
+          MYLEAD_USERNAME: ${{ secrets.MYLEAD_USERNAME }}
+          MYLEAD_PASSWORD: ${{ secrets.MYLEAD_PASSWORD }}
+        run: python get_mylead_token.py
+      - name: Generate offers
+        run: python main.py
+      - name: Copy and commit offer file
+        env:
+          PAT: ${{ secrets.AIQBRAIN_LANDING_PAT }}
+        run: |
+          git clone https://x-access-token:${PAT}@github.com/YourlocalJay/aiqbrain-landing ../aiqbrain-landing
+          cp cloudflare_offers.json ../aiqbrain-landing/public/data/cloudflare_offers.json
+          cd ../aiqbrain-landing
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add public/data/cloudflare_offers.json
+          git commit -m "chore: sync new CPA offers from aggregator" || echo "No changes to commit"
+          git push origin HEAD:main
+

--- a/fetchers/mylead_fetcher.py
+++ b/fetchers/mylead_fetcher.py
@@ -6,11 +6,12 @@ This module contains a helper function for querying the MyLead API and
 translating the response into a uniform offer dictionary format expected by
 the aggregator. MyLead provides a REST API which returns JSON describing
 available CPA offers. To use this fetcher, generate an access token with
-`fetch_mylead_token()` and set the ``MYLEAD_TOKEN`` environment variable.
+`get_mylead_token.py` and ensure the resulting ``mylead_token.txt`` file
+exists in the project root.
 """
 
-import os
 import time
+from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 import requests
@@ -26,12 +27,13 @@ RATE_LIMIT_DELAY = 1  # second between retries
 
 
 def load_mylead_token() -> str:
-    token = os.environ.get("MYLEAD_TOKEN")
-    if token:
-        return token
-    raise RuntimeError(
-        "❌ MYLEAD_TOKEN not found. Run fetch_mylead_token() first."
-    )
+    token_path = Path(__file__).resolve().parent.parent / "mylead_token.txt"
+    try:
+        return token_path.read_text().strip()
+    except OSError:
+        raise RuntimeError(
+            "❌ mylead_token.txt not found. Run get_mylead_token.py first."
+        )
 
 
 def fetch_mylead_offers(params: Optional[dict] = None) -> List[Dict[str, Any]]:

--- a/get_mylead_token.py
+++ b/get_mylead_token.py
@@ -1,4 +1,6 @@
 import os
+from pathlib import Path
+
 import requests
 
 API_URL = "https://api.mylead.eu/api/external/v1/auth/login"
@@ -31,9 +33,17 @@ def fetch_mylead_token() -> str | None:
         print("❌ Login failed: access_token not found in response")
         return None
 
+    token_path = Path(__file__).with_name("mylead_token.txt")
+    try:
+        token_path.write_text(token)
+    except OSError as exc:
+        print(f"❌ Failed to write token file: {exc}")
+        return None
+
     print("✔️ MyLead login successful")
     return token
 
 
 if __name__ == "__main__":
-    fetch_mylead_token()
+    if fetch_mylead_token() is None:
+        raise SystemExit(1)


### PR DESCRIPTION
## Summary
- store MyLead API token in `mylead_token.txt` for reuse
- read token file in MyLead fetcher and emit `cloudflare_offers.json`
- add scheduled workflow to sync offer feed to `aiqbrain-landing`

## Testing
- `ruff check .`
- `mypy .`
- `(python get_mylead_token.py && python main.py && python sync.py)` *(fails: Missing MyLead credentials)*

------
https://chatgpt.com/codex/tasks/task_e_68956313ec5c832f9bbd760f49745a41